### PR TITLE
Handle empty properties when collecting interface metrics

### DIFF
--- a/collector/interface_collector.go
+++ b/collector/interface_collector.go
@@ -73,17 +73,18 @@ func (c *interfaceCollector) collectForStat(re *proto.Sentence, ctx *collectorCo
 
 func (c *interfaceCollector) collectMetricForProperty(property, iface, comment string, re *proto.Sentence, ctx *collectorContext) {
 	desc := c.descriptions[property]
-	v, err := strconv.ParseFloat(re.Map[property], 64)
-	if err != nil {
-		log.WithFields(log.Fields{
-			"device":    ctx.device.Name,
-			"interface": iface,
-			"property":  property,
-			"value":     re.Map[property],
-			"error":     err,
-		}).Error("error parsing interface metric value")
-		return
+	if value := re.Map[property]; value != "" {
+		v, err := strconv.ParseFloat(value, 64)
+		if err != nil {
+			log.WithFields(log.Fields{
+				"device":    ctx.device.Name,
+				"interface": iface,
+				"property":  property,
+				"value":     value,
+				"error":     err,
+			}).Error("error parsing interface metric value")
+			return
+		}
+		ctx.ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue, v, ctx.device.Name, ctx.device.Address, iface, comment)
 	}
-
-	ctx.ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue, v, ctx.device.Name, ctx.device.Address, iface, comment)
 }


### PR DESCRIPTION
Thanks for writing this exporter! I plan to start using it soon™, so expect more PRs :) A small fix to start off with.

Instead of logging an error, check if a property is empty before attempting to call `strconv.ParseFloat` on it.

```
ERRO[0005] error parsing interface metric value device=gw error="strconv.ParseFloat: parsing \"\": invalid syntax" interface=ether2 property=tx-drop value=
```