### PR TITLE
Incorrect param for passing config file

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -4,5 +4,5 @@ if [ -z "$CONFIG_FILE" ]
 then
     /app/mikrotik-exporter -device $DEVICE -address $ADDRESS -user $USER -password $PASSWORD
 else
-    /app/mikrotik-exporter -config $CONFIG_FILE
+    /app/mikrotik-exporter -config-file $CONFIG_FILE
 fi


### PR DESCRIPTION
Entrypoint start script is not correct when trying to pass config file through CONFIG_FILE env var