### PR TITLE
Build 1.0.7 doesn't run in docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM alpine:3.6
 EXPOSE 9436
 
 COPY scripts/start.sh /app/
-COPY dist/mikrotik-exporter_linux_amd64 /app/
+COPY dist/mikrotik-exporter_linux_amd64 /app/mikrotik-exporter
 
 RUN chmod 755 /app/*
 

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -3,7 +3,7 @@ FROM arm32v7/busybox:1.27.2
 EXPOSE 9090
 
 COPY scripts/start.sh /app/
-COPY dist/mikrotik-exporter_linux_arm /app/
+COPY dist/mikrotik-exporter_linux_arm /app/mikrotik-exporter
 
 RUN chmod 755 /app/*
 


### PR DESCRIPTION
This fixes an issue when running build 1.0.7 in docker:

```
➜  mikrotik-exporter git:(master) ✗ docker run -it --rm nshttpd/mikrotik-exporter:1.0.7
/app/start.sh: line 8: /app/mikrotik-exporter: not found
```

This change just forces the name of the executable to match what's expected by the start.sh entrypoint.