### PR TITLE
fixed typo in start.sh permissions assignment

### DIFF
--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ ! -x /app/mikrotik-exporter ]; then
-  chmod 755 /app/mikrotik-expoter
+  chmod 755 /app/mikrotik-exporter
 fi
 
 if [ -z "$CONFIG_FILE" ]


### PR DESCRIPTION
Found a typo in the `start.sh` file that prevented setting the correct execution permissions.