### PR TITLE
Fix validate that string is not empty before strconv.ParseFloat

### DIFF
--- a/collector/dhcp_collector.go
+++ b/collector/dhcp_collector.go
@@ -73,7 +73,9 @@ func (c *dhcpCollector) colllectForDHCPServer(ctx *collectorContext, dhcpServer 
 		}).Error("error fetching DHCP lease counts")
 		return err
 	}
-
+	if reply.Done.Map["ret"] == "" {
+		return nil
+	}
 	v, err := strconv.ParseFloat(reply.Done.Map["ret"], 32)
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/collector/helper.go
+++ b/collector/helper.go
@@ -32,7 +32,9 @@ func description(prefix, name, helpText string, labelNames []string) *prometheus
 
 func splitStringToFloats(metric string) (float64, float64, error) {
 	strs := strings.Split(metric, ",")
-
+	if len(strs) == 0 {
+		return 0, 0, nil
+	}
 	m1, err := strconv.ParseFloat(strs[0], 64)
 	if err != nil {
 		return math.NaN(), math.NaN(), err

--- a/collector/poe_collector.go
+++ b/collector/poe_collector.go
@@ -88,7 +88,9 @@ func (c *poeCollector) collectMetricsForInterface(name string, se *proto.Sentenc
 		if !ok {
 			continue
 		}
-
+		if v == "" {
+			continue
+		}
 		value, err := strconv.ParseFloat(v, 64)
 		if err != nil {
 			log.WithFields(log.Fields{

--- a/collector/pool_collector.go
+++ b/collector/pool_collector.go
@@ -88,7 +88,9 @@ func (c *poolCollector) collectForPool(ipVersion, topic, pool string, ctx *colle
 		}).Error("error fetching pool counts")
 		return err
 	}
-
+	if reply.Done.Map["ret"] == "" {
+		return nil
+	}
 	v, err := strconv.ParseFloat(reply.Done.Map["ret"], 32)
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/collector/resource_collector.go
+++ b/collector/resource_collector.go
@@ -54,7 +54,7 @@ func (c *resourceCollector) collect(ctx *collectorContext) error {
 	}
 
 	for _, re := range stats {
-			c.collectForStat(re, ctx)
+		c.collectForStat(re, ctx)
 	}
 
 	return nil
@@ -82,8 +82,8 @@ func (c *resourceCollector) collectForStat(re *proto.Sentence, ctx *collectorCon
 func (c *resourceCollector) collectMetricForProperty(property string, re *proto.Sentence, ctx *collectorContext) {
 	var v float64
 	var err error
-//	const boardname = "BOARD"
-//	const version = "3.33.3"
+	//	const boardname = "BOARD"
+	//	const version = "3.33.3"
 
 	boardname := re.Map["board-name"]
 	version := re.Map["version"]
@@ -91,6 +91,9 @@ func (c *resourceCollector) collectMetricForProperty(property string, re *proto.
 	if property == "uptime" {
 		v, err = parseUptime(re.Map[property])
 	} else {
+		if re.Map[property] == "" {
+			return
+		}
 		v, err = strconv.ParseFloat(re.Map[property], 64)
 	}
 

--- a/collector/routes_collector.go
+++ b/collector/routes_collector.go
@@ -74,7 +74,9 @@ func (c *routesCollector) colllectCount(ipVersion, topic string, ctx *collectorC
 		}).Error("error fetching routes metrics")
 		return err
 	}
-
+	if reply.Done.Map["ret"] == "" {
+		return nil
+	}
 	v, err := strconv.ParseFloat(reply.Done.Map["ret"], 32)
 	if err != nil {
 		log.WithFields(log.Fields{
@@ -100,7 +102,9 @@ func (c *routesCollector) colllectCountProtcol(ipVersion, topic, protocol string
 		}).Error("error fetching routes metrics")
 		return err
 	}
-
+	if reply.Done.Map["ret"] == "" {
+		return nil
+	}
 	v, err := strconv.ParseFloat(reply.Done.Map["ret"], 32)
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/collector/wlanif_collector.go
+++ b/collector/wlanif_collector.go
@@ -93,7 +93,9 @@ func (c *wlanIFCollector) collectForInterface(iface string, ctx *collectorContex
 func (c *wlanIFCollector) collectMetricForProperty(property, iface string, re *proto.Sentence, ctx *collectorContext) {
 	desc := c.descriptions[property]
 	channel := re.Map["channel"]
-
+	if re.Map[property] == "" {
+		return
+	}
 	v, err := strconv.ParseFloat(re.Map[property], 64)
 	if err != nil {
 		log.WithFields(log.Fields{

--- a/collector/wlansta_collector.go
+++ b/collector/wlansta_collector.go
@@ -78,6 +78,9 @@ func (c *wlanSTACollector) collectForStat(re *proto.Sentence, ctx *collectorCont
 }
 
 func (c *wlanSTACollector) collectMetricForProperty(property, iface, mac string, re *proto.Sentence, ctx *collectorContext) {
+	if re.Map[property] == "" {
+		return
+	}
 	v, err := strconv.ParseFloat(re.Map[property], 64)
 	if err != nil {
 		log.WithFields(log.Fields{


### PR DESCRIPTION
If the api returns "" for a device strconv fails and all collectors get halted.