### PR TITLE
Custom API port

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ devices:
     password: changeme
   - name: my_second_router
     address: 10.10.0.2
+    port: 8999
     user: prometheus2
     password: password_to_second_router
 

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -20,8 +20,8 @@ import (
 
 const (
 	namespace  = "mikrotik"
-	apiPort    = ":8728"
-	apiPortTLS = ":8729"
+	apiPort    = "8728"
+	apiPortTLS = "8729"
 
 	// DefaultTimeout defines the default timeout when connecting to a router
 	DefaultTimeout = 5 * time.Second
@@ -246,7 +246,10 @@ func (c *collector) connect(d *config.Device) (*routeros.Client, error) {
 
 	log.WithField("device", d.Name).Debug("trying to Dial")
 	if !c.enableTLS {
-		conn, err = net.DialTimeout("tcp", d.Address+apiPort, c.timeout)
+		if(d.Port) == "" {
+			d.Port = apiPort
+		}
+		conn, err = net.DialTimeout("tcp", d.Address+":"+d.Port, c.timeout)
 		if err != nil {
 			return nil, err
 		}
@@ -255,10 +258,13 @@ func (c *collector) connect(d *config.Device) (*routeros.Client, error) {
 		tlsCfg := &tls.Config{
 			InsecureSkipVerify: c.insecureTLS,
 		}
+		if(d.Port) == "" {
+			d.Port = apiPortTLS
+		}
 		conn, err = tls.DialWithDialer(&net.Dialer{
 			Timeout: c.timeout,
 		},
-			"tcp", d.Address+apiPortTLS, tlsCfg)
+			"tcp", d.Address+":"+d.Port, tlsCfg)
 		if err != nil {
 			return nil, err
 		}

--- a/config/config.go
+++ b/config/config.go
@@ -31,6 +31,7 @@ type Device struct {
 	Address  string `yaml:"address"`
 	User     string `yaml:"user"`
 	Password string `yaml:"password"`
+	Port	 string `yaml:"port"`
 }
 
 // Load reads YAML from reader and unmashals in Config

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ var (
 	logLevel    = flag.String("log-level", "info", "log level")
 	metricsPath = flag.String("path", "/metrics", "path to answer requests on")
 	password    = flag.String("password", "", "password for authentication for single device")
+	deviceport  = flag.String("deviceport", "8728", "port for single device")
 	port        = flag.String("port", ":9436", "port number to listen on")
 	timeout     = flag.Duration("timeout", collector.DefaultTimeout, "timeout when connecting to devices")
 	tls         = flag.Bool("tls", false, "use tls to connect to routers")
@@ -121,6 +122,7 @@ func loadConfigFromFlags() (*config.Config, error) {
 				Address:  *address,
 				User:     *user,
 				Password: *password,
+				Port: *deviceport,
 			},
 		},
 	}, nil


### PR DESCRIPTION
Adds ability to specify API Port, either via CLI or in config. If port is not provided, default is used, taking into account if TLS is enabled or not