### PR TITLE
Fix routes collector to be compatible with latest RouterOS release

### DIFF
--- a/collector/pool_collector.go
+++ b/collector/pool_collector.go
@@ -30,17 +30,7 @@ func (c *poolCollector) describe(ch chan<- *prometheus.Desc) {
 }
 
 func (c *poolCollector) collect(ctx *collectorContext) error {
-	err := c.collectForIPVersion("4", "ip", ctx)
-	if err != nil {
-		return err
-	}
-
-	err = c.collectForIPVersion("6", "ipv6", ctx)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return c.collectForIPVersion("4", "ip", ctx)
 }
 
 func (c *poolCollector) collectForIPVersion(ipVersion, topic string, ctx *collectorContext) error {

--- a/collector/resource_collector.go
+++ b/collector/resource_collector.go
@@ -119,20 +119,20 @@ func parseUptime(uptime string) (float64, error) {
 	// should get one and only one match back on the regex
 	if len(reMatch) != 1 {
 		return 0, fmt.Errorf("invalid uptime value sent to regex")
-	} else {
-		for i, match := range reMatch[0] {
-			if match != "" && i != 0 {
-				v, err := strconv.Atoi(match)
-				if err != nil {
-					log.WithFields(log.Fields{
-						"uptime": uptime,
-						"value":  match,
-						"error":  err,
-					}).Error("error parsing uptime field value")
-					return float64(0), err
-				}
-				u += time.Duration(v) * uptimeParts[i-1]
+	}
+
+	for i, match := range reMatch[0] {
+		if match != "" && i != 0 {
+			v, err := strconv.Atoi(match)
+			if err != nil {
+				log.WithFields(log.Fields{
+					"uptime": uptime,
+					"value":  match,
+					"error":  err,
+				}).Error("error parsing uptime field value")
+				return float64(0), err
 			}
+			u += time.Duration(v) * uptimeParts[i-1]
 		}
 	}
 	return u.Seconds(), nil

--- a/collector/routes_collector.go
+++ b/collector/routes_collector.go
@@ -40,12 +40,7 @@ func (c *routesCollector) collect(ctx *collectorContext) error {
 		return err
 	}
 
-	err = c.colllectForIPVersion("6", "ipv6", ctx)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return c.colllectForIPVersion("6", "ip", ctx)
 }
 
 func (c *routesCollector) colllectForIPVersion(ipVersion, topic string, ctx *collectorContext) error {
@@ -70,6 +65,7 @@ func (c *routesCollector) colllectCount(ipVersion, topic string, ctx *collectorC
 		log.WithFields(log.Fields{
 			"ip_version": ipVersion,
 			"device":     ctx.device.Name,
+			"topic":      topic,
 			"error":      err,
 		}).Error("error fetching routes metrics")
 		return err


### PR DESCRIPTION
Resolves [64](https://github.com/nshttpd/mikrotik-exporter/issues/64), tested on RouterOS 6.46.1. It does seem that the API has changed for many of the IPv6 stats and the DHCPv6 collector is also broken.