### PR TITLE
Read credentials from env variable if not set

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ where `address` is the address of your router. `device` is the label name for th
 in the metrics output to prometheus. The `user` and `password` are the ones you
 created for the exporter to use to access the API.
 
+User and password flags can be set with the `MIKROTIK_USER` and `MIKROTIK_PASSWORD` environment variables, respectively.
+
+```
+MIKROTIK_USER=prometheus
+MIKROTIK_PASSWORD=changeme
+./mikrotik-exporter -address 10.10.0.1 -device my_router
+```
+
 #### Config File
 
 `./mikrotik-exporter -config-file config.yml`

--- a/main.go
+++ b/main.go
@@ -115,6 +115,13 @@ func loadConfigFromFile() (*config.Config, error) {
 }
 
 func loadConfigFromFlags() (*config.Config, error) {
+	// Attempt to read credentials from env if not already defined
+	if *user == "" {
+		*user = os.Getenv("MIKROTIK_USER")
+	}
+	if *password == "" {
+		*password = os.Getenv("MIKROTIK_PASSWORD")
+	}
 	if *device == "" || *address == "" || *user == "" || *password == "" {
 		return nil, fmt.Errorf("missing required param for single device configuration")
 	}


### PR DESCRIPTION
Allows for secrets to be provided to exporter outside of main configuration. E.G. via Kubernetes Secrets.
Specified configuration files or flags take precedence over environment variables.