### PR TITLE
Use builder to build binary

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,19 @@
-FROM debian:9.9-slim
+FROM golang:alpine as builder
+RUN \
+  cd / && \
+  apk add --no-cache git ca-certificates make && \
+  git clone https://github.com/nshttpd/mikrotik-exporter.git && \
+  cd /mikrotik-exporter && \
+  go get -d -v && \
+  make build
 
-EXPOSE 9436
 
+FROM alpine
 COPY scripts/start.sh /app/
-COPY dist/mikrotik-exporter_linux_amd64 /app/mikrotik-exporter
-
+COPY --from=builder /mikrotik-exporter/mikrotik-exporter /app/mikrotik-exporter
 RUN chmod 755 /app/*
+
+USER nobody
+EXPOSE 9436
 
 ENTRYPOINT ["/app/start.sh"]


### PR DESCRIPTION
Uses same env to build binary (alpine) as will be used to run in. Should not reintroduce #40 
Tested locally, all fine running in archlinux.