### PR TITLE
fix #117 by distinquishing prometheus value types

### DIFF
--- a/collector/interface_collector.go
+++ b/collector/interface_collector.go
@@ -71,16 +71,23 @@ func (c *interfaceCollector) collectMetricForProperty(property string, re *proto
 	desc := c.descriptions[property]
 	if value := re.Map[property]; value != "" {
 		var (
-			v   float64
-			err error
+			v     float64
+			vtype prometheus.ValueType
+			err   error
 		)
+		vtype = prometheus.CounterValue
+
 		switch property {
 		case "running":
+			vtype = prometheus.GaugeValue
 			if value == "true" {
 				v = 1
 			} else {
 				v = 0
 			}
+		case "actual-mtu":
+			vtype = prometheus.GaugeValue
+			fallthrough
 		default:
 			v, err = strconv.ParseFloat(value, 64)
 			if err != nil {
@@ -94,7 +101,8 @@ func (c *interfaceCollector) collectMetricForProperty(property string, re *proto
 				return
 			}
 		}
-		ctx.ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue, v, ctx.device.Name, ctx.device.Address,
+		ctx.ch <- prometheus.MustNewConstMetric(desc, vtype, v, ctx.device.Name, ctx.device.Address,
 			re.Map["name"], re.Map["type"], re.Map["disabled"], re.Map["comment"], re.Map["running"], re.Map["slave"])
+
 	}
 }

--- a/collector/resource_collector.go
+++ b/collector/resource_collector.go
@@ -81,6 +81,7 @@ func (c *resourceCollector) collectForStat(re *proto.Sentence, ctx *collectorCon
 
 func (c *resourceCollector) collectMetricForProperty(property string, re *proto.Sentence, ctx *collectorContext) {
 	var v float64
+	var vtype prometheus.ValueType
 	var err error
 	//	const boardname = "BOARD"
 	//	const version = "3.33.3"
@@ -90,11 +91,13 @@ func (c *resourceCollector) collectMetricForProperty(property string, re *proto.
 
 	if property == "uptime" {
 		v, err = parseUptime(re.Map[property])
+		vtype = prometheus.CounterValue
 	} else {
 		if re.Map[property] == "" {
 			return
 		}
 		v, err = strconv.ParseFloat(re.Map[property], 64)
+		vtype = prometheus.GaugeValue
 	}
 
 	if err != nil {
@@ -108,7 +111,7 @@ func (c *resourceCollector) collectMetricForProperty(property string, re *proto.
 	}
 
 	desc := c.descriptions[property]
-	ctx.ch <- prometheus.MustNewConstMetric(desc, prometheus.CounterValue, v, ctx.device.Name, ctx.device.Address, boardname, version)
+	ctx.ch <- prometheus.MustNewConstMetric(desc, vtype, v, ctx.device.Name, ctx.device.Address, boardname, version)
 }
 
 func parseUptime(uptime string) (float64, error) {


### PR DESCRIPTION
As described by @rkosegi in #117, some metrics are labeled counters even though they are gauges. This PR fixes all of the metrics described by him, but there might be more. I have tested this myself with the `_system_` metrics as it was those which alerted me to the issue. I don't have the `_interface_` metrics in my setup to test.

Even though this directly affects exported metrics, this change should be non-breaking for all users doing sane things with their data.  This would only cause issues when dashboards contain statements such as `rate(mikrotik_system_cpu_load[1m])` which are technically possible but do not make sense. On the contrary, recent versions of Grafana suggest to use a `rate()` function as the metric displayed is labeled a counter, which will confuse new users. Basically, just the functions listed [here](https://prometheus.io/docs/prometheus/latest/querying/functions/) which paragraphs contain the words "should only be used with counters" would be affected by this change (`rate`, `increase`, `resets`).