### PR TITLE
Do not panic on incorrect character in dhcp lease hostname

### DIFF
--- a/collector/dhcp_lease_collector.go
+++ b/collector/dhcp_lease_collector.go
@@ -78,5 +78,13 @@ func (c *dhcpLeaseCollector) collectMetric(ctx *collectorContext, re *proto.Sent
 	activeaddress := re.Map["active-address"]
 	hostname := re.Map["host-name"]
 
-	ctx.ch <- prometheus.MustNewConstMetric(c.descriptions, prometheus.GaugeValue, v, ctx.device.Name, ctx.device.Address, activemacaddress, server, status, strconv.FormatFloat(f, 'f', 0, 64), activeaddress, hostname)
+	metric, err := prometheus.NewConstMetric(c.descriptions, prometheus.GaugeValue, v, ctx.device.Name, ctx.device.Address, activemacaddress, server, status, strconv.FormatFloat(f, 'f', 0, 64), activeaddress, hostname)
+	if err != nil {
+		log.WithFields(log.Fields{
+			"device": ctx.device.Name,
+			"error":  err,
+		}).Error("error parsing dhcp lease")
+		return
+	}
+	ctx.ch <- metric
 }


### PR DESCRIPTION
Collector panics in case when DHCP lease hostname have character that is not valid UTF-8.

Panic example:
```
panic: label value "\x8f\x8a3000-\x8f\x8a" is not valid UTF-8

goroutine 25 [running]:
github.com/prometheus/client_golang/prometheus.MustNewConstMetric(...)
	/root/go/pkg/mod/github.com/prometheus/client_golang@v1.4.1/prometheus/value.go:105
mikrotik-exporter/collector.(*dhcpLeaseCollector).collectMetric(0xc0000ac660, 0xc000302d38, 0xc000359340)
	/root/mikrotik-exporter/collector/dhcp_lease_collector.go:81 +0x6c8
mikrotik-exporter/collector.(*dhcpLeaseCollector).collect(0xc0000b2fc0, 0xc00014a280)
	/root/mikrotik-exporter/collector/dhcp_lease_collector.go:42 +0x65
mikrotik-exporter/collector.(*collector).connectAndCollect(0xc0000b2fc0, 0xc00014a280, 0xc000080960)
	/root/mikrotik-exporter/collector/collector.go:348 +0x36f
mikrotik-exporter/collector.(*collector).collectForDevice(0x0, {{0xc0000ae670, 0xc}, {0xc0000ae690, 0xa}, {{0x0, 0x0}, {{0x0, 0x0}, 0x0}}, ...}, ...)
	/root/mikrotik-exporter/collector/collector.go:319 +0xe5
mikrotik-exporter/collector.(*collector).Collect.func1({{0xc0000ae670, 0xc}, {0xc0000ae690, 0xa}, {{0x0, 0x0}, {{0x0, 0x0}, 0x0}}, {0xc0000ae6b0, ...}, ...})
	/root/mikrotik-exporter/collector/collector.go:284 +0x78
created by mikrotik-exporter/collector.(*collector).Collect
	/root/mikrotik-exporter/collector/collector.go:283 +0x292
```

This merge will fix it