### PR TITLE
TLS and Insecure can be set per device in config yaml

### DIFF
--- a/collector/collector.go
+++ b/collector/collector.go
@@ -48,11 +48,9 @@ var (
 )
 
 type collector struct {
-	devices     []config.Device
-	collectors  []routerOSCollector
-	timeout     time.Duration
-	enableTLS   bool
-	insecureTLS bool
+	devices    []config.Device
+	collectors []routerOSCollector
+	timeout    time.Duration
 }
 
 // WithBGP enables BGP routing metrics
@@ -164,14 +162,6 @@ func Monitor() Option {
 func WithTimeout(d time.Duration) Option {
 	return func(c *collector) {
 		c.timeout = d
-	}
-}
-
-// WithTLS enables TLS
-func WithTLS(insecure bool) Option {
-	return func(c *collector) {
-		c.enableTLS = true
-		c.insecureTLS = insecure
 	}
 }
 
@@ -366,7 +356,7 @@ func (c *collector) connect(d *config.Device) (*routeros.Client, error) {
 	var err error
 
 	log.WithField("device", d.Name).Debug("trying to Dial")
-	if !c.enableTLS {
+	if !d.EnableTLS {
 		if (d.Port) == "" {
 			d.Port = apiPort
 		}
@@ -377,7 +367,7 @@ func (c *collector) connect(d *config.Device) (*routeros.Client, error) {
 		//		return routeros.DialTimeout(d.Address+apiPort, d.User, d.Password, c.timeout)
 	} else {
 		tlsCfg := &tls.Config{
-			InsecureSkipVerify: c.insecureTLS,
+			InsecureSkipVerify: d.InsecureTLS,
 		}
 		if (d.Port) == "" {
 			d.Port = apiPortTLS

--- a/config/config.go
+++ b/config/config.go
@@ -35,12 +35,14 @@ type Config struct {
 
 // Device represents a target device
 type Device struct {
-	Name     string    `yaml:"name"`
-	Address  string    `yaml:"address,omitempty"`
-	Srv      SrvRecord `yaml:"srv,omitempty"`
-	User     string    `yaml:"user"`
-	Password string    `yaml:"password"`
-	Port     string    `yaml:"port"`
+	Name        string    `yaml:"name"`
+	Address     string    `yaml:"address,omitempty"`
+	Srv         SrvRecord `yaml:"srv,omitempty"`
+	User        string    `yaml:"user"`
+	Password    string    `yaml:"password"`
+	Port        string    `yaml:"port"`
+	EnableTLS   bool      `yaml:"tls"`
+	InsecureTLS bool      `yaml:"insecure"`
 }
 
 type SrvRecord struct {

--- a/config/config.test.yml
+++ b/config/config.test.yml
@@ -7,6 +7,9 @@ devices:
     address: 192.168.2.1
     user: test
     password: 123
+    port: 324
+    tls: true
+    insecure: true
 
 features:
   bgp: true

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,6 +19,8 @@ func TestShouldParse(t *testing.T) {
 
 	assertDevice("test1", "192.168.1.1", "foo", "bar", c.Devices[0], t)
 	assertDevice("test2", "192.168.2.1", "test", "123", c.Devices[1], t)
+	assertDeviceConnection("", false, false, c.Devices[0], t)
+	assertDeviceConnection("324", true, true, c.Devices[1], t)
 	assertFeature("BGP", c.Features.BGP, t)
 	assertFeature("Conntrack", c.Features.Conntrack, t)
 	assertFeature("DHCP", c.Features.DHCP, t)
@@ -57,6 +59,19 @@ func assertDevice(name, address, user, password string, c Device, t *testing.T) 
 
 	if c.Password != password {
 		t.Fatalf("expected password %s, got %s", password, c.Password)
+	}
+}
+
+func assertDeviceConnection(port string, tls, insecure bool, c Device, t *testing.T) {
+	if c.Port != port {
+		t.Fatalf("expected port %s, got %s", port, c.Port)
+	}
+
+	if c.EnableTLS != tls {
+		t.Fatalf("expected tls %t, got %t", tls, c.EnableTLS)
+	}
+	if c.InsecureTLS != insecure {
+		t.Fatalf("expected insecure %t, got %t", insecure, c.InsecureTLS)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -133,11 +133,13 @@ func loadConfigFromFlags() (*config.Config, error) {
 	return &config.Config{
 		Devices: []config.Device{
 			config.Device{
-				Name:     *device,
-				Address:  *address,
-				User:     *user,
-				Password: *password,
-				Port:     *deviceport,
+				Name:        *device,
+				Address:     *address,
+				User:        *user,
+				Password:    *password,
+				Port:        *deviceport,
+				EnableTLS:   *tls,
+				InsecureTLS: *insecure,
 			},
 		},
 	}, nil
@@ -276,10 +278,6 @@ func collectorOptions() []collector.Option {
 
 	if *timeout != collector.DefaultTimeout {
 		opts = append(opts, collector.WithTimeout(*timeout))
-	}
-
-	if *tls {
-		opts = append(opts, collector.WithTLS(*insecure))
 	}
 
 	return opts


### PR DESCRIPTION
* Adds `tls` (default: false) option to device settings in config file
* Adds `insecure` (default: false) option to device settings in config file
* Moves `tls` and `insecure` connection option settings from collector to device, allowing to have mixed connections for devices in yaml config file