### PR TITLE
TLS and Insecure can be set per device in config yaml

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ devices:
     address: 10.10.0.1
     user: prometheus
     password: changeme
+    port: 8729
+    tls: true
+    insecure: true
   - name: my_second_router
     address: 10.10.0.2
     port: 8999

--- a/collector/collector.go
+++ b/collector/collector.go
@@ -48,11 +48,9 @@ var (
 )
 
 type collector struct {
-	devices     []config.Device
-	collectors  []routerOSCollector
-	timeout     time.Duration
-	enableTLS   bool
-	insecureTLS bool
+	devices    []config.Device
+	collectors []routerOSCollector
+	timeout    time.Duration
 }
 
 // WithBGP enables BGP routing metrics
@@ -164,14 +162,6 @@ func Monitor() Option {
 func WithTimeout(d time.Duration) Option {
 	return func(c *collector) {
 		c.timeout = d
-	}
-}
-
-// WithTLS enables TLS
-func WithTLS(insecure bool) Option {
-	return func(c *collector) {
-		c.enableTLS = true
-		c.insecureTLS = insecure
 	}
 }
 
@@ -366,7 +356,7 @@ func (c *collector) connect(d *config.Device) (*routeros.Client, error) {
 	var err error
 
 	log.WithField("device", d.Name).Debug("trying to Dial")
-	if !c.enableTLS {
+	if !d.EnableTLS {
 		if (d.Port) == "" {
 			d.Port = apiPort
 		}
@@ -377,7 +367,7 @@ func (c *collector) connect(d *config.Device) (*routeros.Client, error) {
 		//		return routeros.DialTimeout(d.Address+apiPort, d.User, d.Password, c.timeout)
 	} else {
 		tlsCfg := &tls.Config{
-			InsecureSkipVerify: c.insecureTLS,
+			InsecureSkipVerify: d.InsecureTLS,
 		}
 		if (d.Port) == "" {
 			d.Port = apiPortTLS

--- a/config/config.go
+++ b/config/config.go
@@ -35,12 +35,14 @@ type Config struct {
 
 // Device represents a target device
 type Device struct {
-	Name     string    `yaml:"name"`
-	Address  string    `yaml:"address,omitempty"`
-	Srv      SrvRecord `yaml:"srv,omitempty"`
-	User     string    `yaml:"user"`
-	Password string    `yaml:"password"`
-	Port     string    `yaml:"port"`
+	Name        string    `yaml:"name"`
+	Address     string    `yaml:"address,omitempty"`
+	Srv         SrvRecord `yaml:"srv,omitempty"`
+	User        string    `yaml:"user"`
+	Password    string    `yaml:"password"`
+	Port        string    `yaml:"port"`
+	EnableTLS   bool      `yaml:"tls"`
+	InsecureTLS bool      `yaml:"insecure"`
 }
 
 type SrvRecord struct {

--- a/config/config.go
+++ b/config/config.go
@@ -1,10 +1,11 @@
 package config
 
 import (
+	log "github.com/sirupsen/logrus"
 	"io"
 	"io/ioutil"
 
-	yaml "gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v2"
 )
 
 // Config represents the configuration for the exporter
@@ -40,9 +41,9 @@ type Device struct {
 	Srv         SrvRecord `yaml:"srv,omitempty"`
 	User        string    `yaml:"user"`
 	Password    string    `yaml:"password"`
-	Port        string    `yaml:"port"`
-	EnableTLS   bool      `yaml:"tls"`
-	InsecureTLS bool      `yaml:"insecure"`
+	Port        string    `yaml:"port,omitempty"`
+	EnableTLS   bool      `yaml:"tls,omitempty"`
+	InsecureTLS bool      `yaml:"insecure,omitempty"`
 }
 
 type SrvRecord struct {
@@ -54,7 +55,7 @@ type DnsServer struct {
 	Port    int    `yaml:"port"`
 }
 
-// Load reads YAML from reader and unmashals in Config
+// Load reads YAML from reader and unmarshalls in Config
 func Load(r io.Reader) (*Config, error) {
 	b, err := ioutil.ReadAll(r)
 	if err != nil {
@@ -68,4 +69,16 @@ func Load(r io.Reader) (*Config, error) {
 	}
 
 	return c, nil
+}
+
+func (d *Device) UnmarshalYAML(unmarshal func(interface{}) error) error {
+	type inputDevice Device
+	defaults := &inputDevice{Port: "8728", EnableTLS: false, InsecureTLS: false}
+	err := unmarshal(defaults)
+	if err != nil {
+		log.WithError(err).Error("Device unmarshal error")
+		return err
+	}
+	*d = (Device)(*defaults)
+	return nil
 }

--- a/config/config.test.yml
+++ b/config/config.test.yml
@@ -7,6 +7,9 @@ devices:
     address: 192.168.2.1
     user: test
     password: 123
+    port: 324
+    tls: true
+    insecure: true
 
 features:
   bgp: true

--- a/config/config.test.yml
+++ b/config/config.test.yml
@@ -6,8 +6,8 @@ devices:
   - name: test2
     address: 192.168.2.1
     user: test
-    password: 123
-    port: 324
+    password: '123'
+    port: '324'
     tls: true
     insecure: true
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,7 +19,7 @@ func TestShouldParse(t *testing.T) {
 
 	assertDevice("test1", "192.168.1.1", "foo", "bar", c.Devices[0], t)
 	assertDevice("test2", "192.168.2.1", "test", "123", c.Devices[1], t)
-	assertDeviceConnection("", false, false, c.Devices[0], t)
+	assertDeviceConnection("8728", false, false, c.Devices[0], t)
 	assertDeviceConnection("324", true, true, c.Devices[1], t)
 	assertFeature("BGP", c.Features.BGP, t)
 	assertFeature("Conntrack", c.Features.Conntrack, t)

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -19,6 +19,8 @@ func TestShouldParse(t *testing.T) {
 
 	assertDevice("test1", "192.168.1.1", "foo", "bar", c.Devices[0], t)
 	assertDevice("test2", "192.168.2.1", "test", "123", c.Devices[1], t)
+	assertDeviceConnection("", false, false, c.Devices[0], t)
+	assertDeviceConnection("324", true, true, c.Devices[1], t)
 	assertFeature("BGP", c.Features.BGP, t)
 	assertFeature("Conntrack", c.Features.Conntrack, t)
 	assertFeature("DHCP", c.Features.DHCP, t)
@@ -57,6 +59,19 @@ func assertDevice(name, address, user, password string, c Device, t *testing.T) 
 
 	if c.Password != password {
 		t.Fatalf("expected password %s, got %s", password, c.Password)
+	}
+}
+
+func assertDeviceConnection(port string, tls, insecure bool, c Device, t *testing.T) {
+	if c.Port != port {
+		t.Fatalf("expected port %s, got %s", port, c.Port)
+	}
+
+	if c.EnableTLS != tls {
+		t.Fatalf("expected tls %t, got %t", tls, c.EnableTLS)
+	}
+	if c.InsecureTLS != insecure {
+		t.Fatalf("expected insecure %t, got %t", insecure, c.InsecureTLS)
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -133,11 +133,13 @@ func loadConfigFromFlags() (*config.Config, error) {
 	return &config.Config{
 		Devices: []config.Device{
 			config.Device{
-				Name:     *device,
-				Address:  *address,
-				User:     *user,
-				Password: *password,
-				Port:     *deviceport,
+				Name:        *device,
+				Address:     *address,
+				User:        *user,
+				Password:    *password,
+				Port:        *deviceport,
+				EnableTLS:   *tls,
+				InsecureTLS: *insecure,
 			},
 		},
 	}, nil
@@ -276,10 +278,6 @@ func collectorOptions() []collector.Option {
 
 	if *timeout != collector.DefaultTimeout {
 		opts = append(opts, collector.WithTimeout(*timeout))
-	}
-
-	if *tls {
-		opts = append(opts, collector.WithTLS(*insecure))
 	}
 
 	return opts


### PR DESCRIPTION
* Adds `port` (default `8728`) setting to device setting in config file
* Adds `tls` (default: `false`) option to device settings in config file
* Adds `insecure` (default: `false`) option to device settings in config file
* Moves `tls` and `insecure` connection options settings from collector to device, allowing to have mixed connections for devices in yaml config file
* updates README.md