### PR TITLE
monitor: add 2.5G rate for interfaces

### DIFF
--- a/collector/monitor_collector.go
+++ b/collector/monitor_collector.go
@@ -107,6 +107,8 @@ func (c *monitorCollector) valueForProp(name, value string) int {
 				return 100
 			case v == "1Gbps":
 				return 1000
+		  case v == "2.5Gbps":
+  		  return 2500
 			case v == "10Gbps":
 				return 10000
 			}


### PR DESCRIPTION
Like #73 but for 2.5G, since the RB5009 has a 2.5GBase-T port.

I imagine 5G will be the same, but I don't have a device to test that with.