### PR TITLE
fix: sanitize non-UTF-8 interface label values

### DIFF
--- a/collector/helper.go
+++ b/collector/helper.go
@@ -7,6 +7,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/prometheus/client_golang/prometheus"
 	log "github.com/sirupsen/logrus"
@@ -22,6 +23,17 @@ func init() {
 
 func metricStringCleanup(in string) string {
 	return strings.Replace(in, "-", "_", -1)
+}
+
+// cleanLabelValue replaces invalid UTF-8 byte sequences with the Unicode
+// replacement character so that free-form RouterOS fields such as interface
+// comments, which may use a non-UTF-8 encoding, do not crash
+// prometheus.MustNewConstMetric.
+func cleanLabelValue(in string) string {
+	if utf8.ValidString(in) {
+		return in
+	}
+	return strings.ToValidUTF8(in, "�")
 }
 
 func descriptionForPropertyName(prefix, property string, labelNames []string) *prometheus.Desc {

--- a/collector/helper_test.go
+++ b/collector/helper_test.go
@@ -3,9 +3,27 @@ package collector
 import (
 	"math"
 	"testing"
+	"unicode/utf8"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestCleanLabelValue(t *testing.T) {
+	// "künden." encoded as Windows-1252/Latin-1, as returned by some RouterOS devices.
+	invalid := "k\xfcnden."
+
+	assert.False(t, utf8.ValidString(invalid))
+
+	cleaned := cleanLabelValue(invalid)
+	assert.True(t, utf8.ValidString(cleaned))
+	assert.Equal(t, "künden.", cleanLabelValue("künden."))
+
+	desc := prometheus.NewDesc("test_metric", "", []string{"comment"}, nil)
+	assert.NotPanics(t, func() {
+		prometheus.MustNewConstMetric(desc, prometheus.GaugeValue, 1, cleaned)
+	})
+}
 
 func TestSplitStringToFloats(t *testing.T) {
 	var testCases = []struct {

--- a/collector/interface_collector.go
+++ b/collector/interface_collector.go
@@ -102,7 +102,8 @@ func (c *interfaceCollector) collectMetricForProperty(property string, re *proto
 			}
 		}
 		ctx.ch <- prometheus.MustNewConstMetric(desc, vtype, v, ctx.device.Name, ctx.device.Address,
-			re.Map["name"], re.Map["type"], re.Map["disabled"], re.Map["comment"], re.Map["running"], re.Map["slave"])
+			cleanLabelValue(re.Map["name"]), cleanLabelValue(re.Map["type"]), cleanLabelValue(re.Map["disabled"]),
+			cleanLabelValue(re.Map["comment"]), cleanLabelValue(re.Map["running"]), cleanLabelValue(re.Map["slave"]))
 
 	}
 }


### PR DESCRIPTION
RouterOS returns free-form fields such as interface comments in a non-UTF-8 encoding, which makes `prometheus.MustNewConstMetric` panic and crash the exporter (#142). This adds a `cleanLabelValue` helper that replaces invalid UTF-8 with the replacement character and applies it to the interface collector's label values. Closes #142